### PR TITLE
Replace log4j 1.x with SLF4J

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/.classpath
+/.project
+/.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -162,9 +162,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.26</version>
 		</dependency>
 
 		<!-- JSon Parsing Library from Google -->
@@ -189,6 +189,12 @@
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.26</version>
+      <scope>test</scope>
+    </dependency>
 
 		<!-- UI Test dependencies Selenium -->
 		<dependency>

--- a/src/main/java/com/heidelpay/payment/communication/JsonURLConverter.java
+++ b/src/main/java/com/heidelpay/payment/communication/JsonURLConverter.java
@@ -24,7 +24,8 @@ import java.lang.reflect.Type;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -36,7 +37,7 @@ import com.google.gson.JsonSerializer;
 
 public class JsonURLConverter
 		implements JsonDeserializer<URL>, JsonSerializer<URL> {
-	public final static Logger logger = Logger.getLogger(JsonURLConverter.class);
+	public final static Logger logger = LoggerFactory.getLogger(JsonURLConverter.class);
 
 	@Override
 	public URL deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)

--- a/src/main/java/com/heidelpay/payment/communication/impl/HttpClientBasedRestCommunication.java
+++ b/src/main/java/com/heidelpay/payment/communication/impl/HttpClientBasedRestCommunication.java
@@ -29,7 +29,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.heidelpay.payment.communication.AbstractHeidelpayRestCommunication;
 import com.heidelpay.payment.communication.HeidelpayHttpRequest;
@@ -43,7 +44,7 @@ import com.heidelpay.payment.communication.HttpCommunicationException;
  */
 public class HttpClientBasedRestCommunication extends AbstractHeidelpayRestCommunication {
 
-	private final static Logger logger = Logger.getLogger(AbstractHeidelpayRestCommunication.class);
+	private final static Logger logger = LoggerFactory.getLogger(AbstractHeidelpayRestCommunication.class);
 
 	public HttpClientBasedRestCommunication() {
 		super(null);
@@ -70,7 +71,7 @@ public class HttpClientBasedRestCommunication extends AbstractHeidelpayRestCommu
 
 	@Override
 	protected void logResponse(HeidelpayHttpResponse response) {
-		logger.debug(response.getStatusCode());
+		logger.debug(String.valueOf(response.getStatusCode()));
 		logger.debug(response.getContent());
 	}
 

--- a/src/main/java/com/heidelpay/payment/communication/impl/RestCommunication.java
+++ b/src/main/java/com/heidelpay/payment/communication/impl/RestCommunication.java
@@ -33,7 +33,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.heidelpay.payment.PaymentException;
 import com.heidelpay.payment.communication.HeidelpayRestCommunication;
@@ -48,7 +49,7 @@ import com.heidelpay.payment.communication.json.JsonErrorObject;
  */
 public class RestCommunication implements HeidelpayRestCommunication {
 
-	private final static Logger logger = Logger.getLogger(RestCommunication.class);
+	private final static Logger logger = LoggerFactory.getLogger(RestCommunication.class);
 
 	public String httpGet(String url, String privateKey) throws HttpCommunicationException {
 		HttpGet httpGet = getHttpGet(url);
@@ -109,14 +110,14 @@ public class RestCommunication implements HeidelpayRestCommunication {
 
 	private String execute(HttpUriRequest httpPost) throws HttpCommunicationException {
 		CloseableHttpResponse response = null;
-		logger.debug(httpPost);
+		logger.debug(String.valueOf(httpPost));
 		try {
 			response = getHttpClient().execute(httpPost);
 
 			StatusLine status = response.getStatusLine();
 			String content;
 			content = EntityUtils.toString(response.getEntity());
-			logger.debug(status);
+			logger.debug(String.valueOf(status));
 			logger.debug(content);
 
 			if (status.getStatusCode() > 201 || status.getStatusCode() < 200) {

--- a/src/main/java/com/heidelpay/payment/service/PropertiesUtil.java
+++ b/src/main/java/com/heidelpay/payment/service/PropertiesUtil.java
@@ -23,10 +23,11 @@ package com.heidelpay.payment.service;
 import java.io.IOException;
 import java.util.Properties;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PropertiesUtil {
-	public final static Logger logger = Logger.getLogger(PropertiesUtil.class);
+	public final static Logger logger = LoggerFactory.getLogger(PropertiesUtil.class);
 	public final static String REST_ENDPOINT = "rest.endpoint"; 
 	public final static String REST_VERSION = "rest.version"; 
 	

--- a/src/main/java/com/heidelpay/payment/service/UrlUtil.java
+++ b/src/main/java/com/heidelpay/payment/service/UrlUtil.java
@@ -23,7 +23,8 @@ package com.heidelpay.payment.service;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.heidelpay.payment.Recurring;
 import com.heidelpay.payment.paymenttypes.PaymentType;
@@ -39,7 +40,7 @@ public class UrlUtil {
 
 	private static final String RECURRING_URL = "types/<typeId>/recurring";
 
-	public final static Logger logger = Logger.getLogger(UrlUtil.class);
+	public final static Logger logger = LoggerFactory.getLogger(UrlUtil.class);
 
 	private PropertiesUtil properties = new PropertiesUtil();
 


### PR DESCRIPTION
Because some frameworks don't use LOG4J 1x (but e.g. LOG4J 2.x or Logback), using the SLF4J abstraction layer adds some benefit here.