### PR TITLE
UMCS-41 Fix SDK-Usage and Test execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<additionalparam>-Xdoclint:none</additionalparam>
 		<skip.dependency.check>true</skip.dependency.check>
-		<publickey1>${publickey1}</publickey1>
-		<privatekey1>${privatekey1}</privatekey1>
-		<privatekey2>${privatekey2}</privatekey2>
-		<privatekey3>${privatekey3}</privatekey3>
-		<marketplacePrivatekey>${marketplacePrivatekey}</marketplacePrivatekey>
 	</properties>
 
 	<distributionManagement>

--- a/src/main/java/com/heidelpay/payment/service/PropertiesUtil.java
+++ b/src/main/java/com/heidelpay/payment/service/PropertiesUtil.java
@@ -47,8 +47,11 @@ public class PropertiesUtil {
 			loadedProperties.load(this.getClass().getResourceAsStream("/heidelpay.properties"));
 			this.properties = loadedProperties;
 
-			loadedProperties.load(this.getClass().getResourceAsStream("/test-keys.properties"));
-			this.properties.putAll(loadedProperties);
+			this.properties.put(PUBLIC_KEY1, System.getProperty(PUBLIC_KEY1));
+			this.properties.put(PRIVATE_KEY1, System.getProperty(PRIVATE_KEY1));
+			this.properties.put(PRIVATE_KEY2, System.getProperty(PRIVATE_KEY2));
+			this.properties.put(PRIVATE_KEY3, System.getProperty(PRIVATE_KEY3));
+			this.properties.put(MARKETPLACE_PRIVATE_KEY, System.getProperty(MARKETPLACE_PRIVATE_KEY));
 		} catch (IOException e) {
 			logger.error("Error loading heidelpay.properties from Classpath: %s", e.getMessage());
 			throw new PropertiesException("Error loading heidelpay.properties from Classpath: " + e.getMessage());


### PR DESCRIPTION
- The private and public key now needs to be provided via the command line
- Removed a broken maven plugin usage from the pom.xml file which causes the plugin to not work properly